### PR TITLE
Fix missing namespace reference

### DIFF
--- a/server-netfx/Controllers/AuditLogsController.cs
+++ b/server-netfx/Controllers/AuditLogsController.cs
@@ -1,8 +1,8 @@
 using System.Linq;
 using System.Web.Http;
-using ServerNetFx.Data;
+using AalaNiroo.Api.Data;
 
-namespace ServerNetFx.Controllers
+namespace AalaNiroo.Api.Controllers
 {
     [Authorize]
     [RoutePrefix("api/audit-logs")]

--- a/server-netfx/Controllers/AuthController.cs
+++ b/server-netfx/Controllers/AuthController.cs
@@ -5,10 +5,10 @@ using System.Security.Claims;
 using System.Text;
 using System.Web.Http;
 using Microsoft.IdentityModel.Tokens;
-using ServerNetFx.Data;
-using ServerNetFx.Services;
+using AalaNiroo.Api.Data;
+using AalaNiroo.Api.Services;
 
-namespace ServerNetFx.Controllers
+namespace AalaNiroo.Api.Controllers
 {
     [RoutePrefix("api/auth")]
     public class AuthController : ApiController

--- a/server-netfx/Controllers/UsersController.cs
+++ b/server-netfx/Controllers/UsersController.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Linq;
 using System.Web.Http;
-using ServerNetFx.Data;
-using ServerNetFx.Models;
-using ServerNetFx.Services;
+using AalaNiroo.Api.Data;
+using AalaNiroo.Api.Models;
+using AalaNiroo.Api.Services;
 
-namespace ServerNetFx.Controllers
+namespace AalaNiroo.Api.Controllers
 {
     [Authorize]
     [RoutePrefix("api/users")]

--- a/server-netfx/Data/AppDbContext.cs
+++ b/server-netfx/Data/AppDbContext.cs
@@ -1,7 +1,7 @@
 using System.Data.Entity;
-using ServerNetFx.Models;
+using AalaNiroo.Api.Models;
 
-namespace ServerNetFx.Data
+namespace AalaNiroo.Api.Data
 {
     public class AppDbContext : DbContext
     {

--- a/server-netfx/Global.asax
+++ b/server-netfx/Global.asax
@@ -1,9 +1,11 @@
 <%@ Application Language="C#" %>
 <%@ Import Namespace="System.Web.Http" %>
+<%@ Import Namespace="AalaNiroo.Api" %>
+<%@ Import Namespace="AalaNiroo.Api.Services" %>
 <script runat="server">
     void Application_Start(object sender, EventArgs e)
     {
         GlobalConfiguration.Configure(WebApiConfig.Register);
-        ServerNetFx.Seed.Ensure();
+        AalaNiroo.Api.Seed.Ensure();
     }
 </script>

--- a/server-netfx/Models/AuditLog.cs
+++ b/server-netfx/Models/AuditLog.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace ServerNetFx.Models
+namespace AalaNiroo.Api.Models
 {
     public class AuditLog
     {

--- a/server-netfx/Models/User.cs
+++ b/server-netfx/Models/User.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 
-namespace ServerNetFx.Models
+namespace AalaNiroo.Api.Models
 {
     public class User
     {

--- a/server-netfx/Seed.cs
+++ b/server-netfx/Seed.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Linq;
-using ServerNetFx.Data;
-using ServerNetFx.Models;
-using ServerNetFx.Services;
+using AalaNiroo.Api.Data;
+using AalaNiroo.Api.Models;
+using AalaNiroo.Api.Services;
 
-namespace ServerNetFx
+namespace AalaNiroo.Api
 {
     public static class Seed
     {

--- a/server-netfx/Services/PasswordHasher.cs
+++ b/server-netfx/Services/PasswordHasher.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 
-namespace ServerNetFx.Services
+namespace AalaNiroo.Api.Services
 {
     public static class PasswordHasher
     {


### PR DESCRIPTION
Rename the root namespace from `ServerNetFx` to `AalaNiroo.Api` to resolve a `CS0246` compilation error.

The error occurred because the deployed `Global.asax` expected `AalaNiroo` namespaces, while the codebase used `ServerNetFx`. This change standardizes the namespace across the application, aligning it with the `AalaNiroo.Api` namespace.

---
<a href="https://cursor.com/background-agent?bcId=bc-50d2ba54-1d9b-4267-a943-2cc890ed3e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50d2ba54-1d9b-4267-a943-2cc890ed3e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

