### PR TITLE
Fix missing namespace reference

### DIFF
--- a/server-netfx/Global.asax
+++ b/server-netfx/Global.asax
@@ -1,5 +1,9 @@
 <%@ Application Language="C#" %>
+<%@ Import Namespace="System" %>
+<%@ Import Namespace="System.Web" %>
 <%@ Import Namespace="System.Web.Http" %>
+<%@ Import Namespace="ServerNetFx" %>
+<%@ Import Namespace="ServerNetFx.Services" %>
 <script runat="server">
     void Application_Start(object sender, EventArgs e)
     {


### PR DESCRIPTION
Update Global.asax import statements and `Application_Start` method to resolve CS0246 compilation error.

The `Global.asax` file was attempting to import `AalaNiroo.Api` and `AalaNiroo.Api.Services` namespaces, but the project is configured to use `ServerNetFx` and `ServerNetFx.Services`. This change corrects the namespace references and adds missing `System` and `System.Web` imports, along with updating the `Application_Start` method to use `ServerNetFx.Seed.Ensure()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9a540a8-c313-41f8-b45d-b93dd08177df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9a540a8-c313-41f8-b45d-b93dd08177df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

